### PR TITLE
Remove global hackathon seoul

### DIFF
--- a/api/1.0/2015/07.json
+++ b/api/1.0/2015/07.json
@@ -17,24 +17,6 @@
       "twitterURL": "https://twitter.com/PrimeHackOrg",
       "googlePlusURL": "",
       "notes": ""
-    },
-    {
-      "title": "Global Hackathon Seoul",
-      "url": "http://seoul.globalhackathon.io/",
-      "startDate": "July 29",
-      "endDate": "August 1",
-      "year": "2015",
-      "city": "Seoul, SCA, South Korea",
-      "host": "Global Hackathon",
-      "length": "36",
-      "size": "2000",
-      "travel": "yes",
-      "prize": "yes",
-      "highSchoolers": "yes",
-      "facebookURL": "https://www.facebook.com/GHSeoul",
-      "twitterURL": "https://twitter.com/GHSeoul",
-      "googlePlusURL": "",
-      "notes": ""
     }
   ]
 }


### PR DESCRIPTION
Global Hackathon Seoul was cancelled (http://blog.globalhackathon.io/cancellation/)