### PR TITLE
Add HackathonHowFar to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Projects Using Hackalist's API
 =================================
 * [Mapathon - Mapping Hackathons](http://mding5692.github.io/mapathon/prototype.html) by [Michael Ding](https://github.com/mding5692)
 * [CoderCalendar](https://github.com/nishanthvijayan/CoderCalendar), an Android app, Chrome extension, and Firefox add-on that lists upcoming coding contests and allows users to easily add them to their Google Calendar.
+* [HackathonHowFar](https://github.com/JoshuaRLi/HackathonHowFar), a small Python script that outputs distance + driving time to a currently available hackathon from a given origin location.
 
 API
 =================================


### PR DESCRIPTION
I made a little Python script today to make hackathon location + drive distance lookup less painful and it uses your 1.0 API! Thanks for Hackalist, it's really great!