### PR TITLE
corrected hackdartmouth location

### DIFF
--- a/api/1.0/2016/09.json
+++ b/api/1.0/2016/09.json
@@ -177,7 +177,7 @@
       "startDate": "September 24",
       "endDate": "September 25",
       "year": "2016",
-      "city": "New York, NY, United States",
+      "city": "Hanover, NH, United States",
       "host": "Dartmouth College",
       "length": "24",
       "size": "unknown",


### PR DESCRIPTION
hackdartmouth is actually being hosted in hanover, nh