### PR TITLE
Add jacobsHack! Fall 2016 to the database

### DIFF
--- a/api/1.0/2016/10.json
+++ b/api/1.0/2016/10.json
@@ -229,6 +229,25 @@
       "googlePlusURL": "",
       "notes": ""
     },
+    {
+      "title": "jacobsHack!",
+      "url": "https://2016f.jacobshack.com/",
+      "startDate": "October 15",
+      "endDate": "October 16",
+      "year": "2016",
+      "city": "Bremen, Germany",
+      "host": "Jacobs University",
+      "length": "24",
+      "size": "200+",
+      "travel": "yes",
+      "prize": "yes",
+      "highSchoolers": "yes",
+      "cost": "free",
+      "facebookURL": "https://www.facebook.com/jacobshack.bremen/",
+      "twitterURL": "https://twitter.com/jacobs_hack",
+      "googlePlusURL": "",
+      "notes": ""
+    },
 	{
       "title": "QuackCon",
       "url": "http://www.quackcon.com/",


### PR DESCRIPTION
Add jacobsHack (https://2016f.jacobshack.com) to api/1.0/2016/10.json
The hackathon is already over but is being added for archiving purposes.