### PR TITLE
Remove line-height 80% attribute

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -63,7 +63,6 @@ p
 .info-line-sm
 {
 	font-size: 14px;
-	line-height: 80%;
 }
 .travel-reimbursement img,.prizes img,.high-schoolers img
 {


### PR DESCRIPTION
Increase readability in hackathon descriptions

# Before change

![issue](https://cloud.githubusercontent.com/assets/15222678/25068361/7f7f67b8-2226-11e7-9bf3-83f762276531.png)


# After change

![noissue](https://cloud.githubusercontent.com/assets/15222678/25068362/82e7f438-2226-11e7-926a-f5c5b3f0417d.png)
