### PR TITLE
update HackathonHowFar project link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Projects Using Hackalist's API
 =================================
 * [Mapathon - Mapping Hackathons](http://mding5692.github.io/mapathon/prototype.html) by [Michael Ding](https://github.com/mding5692)
 * [CoderCalendar](https://github.com/nishanthvijayan/CoderCalendar), an Android app, Chrome extension, and Firefox add-on that lists upcoming coding contests and allows users to easily add them to their Google Calendar.
-* [HackathonHowFar](https://github.com/JoshuaRLi/HackathonHowFar), a small Python script that outputs distance + driving time to a currently available hackathon from a given origin location.
+* [HackathonHowFar](https://github.com/JoshuaRLiArchives/HackathonHowFar), a small Python script that outputs distance + driving time to a currently available hackathon from a given origin location.
 
 API
 =================================


### PR DESCRIPTION
It's been a long time, and I've since moved that old project to an archival account, so I'm updating the link to HackathonHowFar in your README :tada: 

#148 for reference.