### PR TITLE
Add Hack The Police to December 2017 listing

### DIFF
--- a/api/1.0/2017/12.json
+++ b/api/1.0/2017/12.json
@@ -26,7 +26,7 @@
       "endDate": "December 10",
       "year": "2017",
       "city": "London, UK",
-      "host": "Goldsmiths Forensic Psychology Unit, and Police:Now",
+      "host": "Independent committee working alongside Goldsmiths College Forensic Psychology Unit, and Police:Now",
       "length": "36",
       "size": "40",
       "travel": "no",


### PR DESCRIPTION
Hack the Police 2 is running in London, UK, 9th-10th December 2017.