### PR TITLE
Add Scaling Trust in the Age of AI Global Hackathon (Nov 2025)

### DIFF
--- a/api/1.0/2025/api/1.0/2025/12.json
+++ b/api/1.0/2025/api/1.0/2025/12.json
@@ -1,0 +1,20 @@
+{
+  "November": [
+    {
+      "title": "Scaling trust in the age of AI. Global Hackathon - Supported by OriginTrail x Polkadot x Umanitek",
+      "url": "https://dorahacks.io/hackathon/origintrail-scaling-trust-ai/hackers",
+      "startDate": "2025-11-03",
+      "endDate": "2025-11-21",
+      "year": "2025",
+      "city": "Online",
+      "host": "OriginTrail, Umanitek & Polkadot",
+      "length": "18 days",
+      "size": "100+",
+      "travel": "Available for selected participants",
+      "prize": "$30k Pool",
+      "highSchoolers": "false",
+      "cost": "Free",
+      "notes": "Build on the Decentralized Knowledge Graph (DKG) to power AI agents with verifiable provenance, trusted content trails, and decentralized attribution."
+    }
+  ]
+}


### PR DESCRIPTION
This pull request adds the Scaling Trust in the Age of AI global hackathon (November 3–21, 2025), supported by OriginTrail, Polkadot, and Umanitek - inviting developers to build AI agents with verifiable provenance on the Decentralized Knowledge Graph (DKG).